### PR TITLE
onColorChange return hexColor and hsvColor

### DIFF
--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -130,7 +130,7 @@ export class ColorWheel extends Component {
     const {deg, radius} = this.calcPolar(nativeEvent)
     const currentColor = colorsys.hsv2Hex({h: deg, s: 100 * ((radius < 1) ? radius : 1), v: 100})
     this.setState({currentColor})
-    this.props.onColorChange({h: deg, s: 100 * ((radius < 1) ? radius : 1), v: 100})
+    this.props.onColorChange({hexColor: currentColor,hsvColor: {h: deg, s: 100 * ((radius < 1) ? radius : 1), v: 100}})
   }
 
   forceUpdate = color => {


### PR DESCRIPTION
@jsdario What do you think about this?
I update the return value **on the props of onColorChange, add hexColor.**
then user can use this hexColor to set text color or backgroundColor etc.

```
 updateColor = ({nativeEvent}) => {
    const {deg, radius} = this.calcPolar(nativeEvent)
    const currentColor = colorsys.hsv2Hex({h: deg, s: 100 * ((radius < 1) ? radius : 1), v: 100})
    this.setState({currentColor})
    this.props.onColorChange({hexColor: currentColor,hsvColor: {h: deg, s: 100 * ((radius < 1) ? radius : 1), v: 100}})


  }
```