### PR TITLE
Add default export

### DIFF
--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -214,6 +214,8 @@ export class ColorWheel extends Component {
   }
 }
 
+export default ColorWheel
+
 const styles = StyleSheet.create({
   coverResponder: {
     flex: 1,

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ import {
   StyleSheet,
   View
 } from 'react-native';
-import { ColorWheel } from 'react-native-color-wheel';
+import ColorWheel from 'react-native-color-wheel';
 
 export default class Example extends Component {
   render() {


### PR DESCRIPTION
Since there is only a single class, export it as default seems more reasonable.