### PR TITLE
Added onColorChangeComplete prop

### DIFF
--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -16,7 +16,6 @@ export class ColorWheel extends Component {
     thumbSize: 50,
     initialColor: '#ffffff',
     onColorChange: () => {},
-    precision: 0,
   }
 
   constructor (props) {

--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -67,6 +67,10 @@ export class ColorWheel extends Component {
         if (radius < 0.1) {
           this.forceUpdate('#ffffff')
         }
+
+        if (this.props.onColorChangeComplete) {
+          this.props.onColorChangeComplete(this.state.hsv);
+        }
       },
     })
   }
@@ -147,9 +151,10 @@ export class ColorWheel extends Component {
 
   updateColor = ({nativeEvent}) => {
     const {deg, radius} = this.calcPolar(nativeEvent)
-    const currentColor = colorsys.hsv2Hex({h: deg, s: 100 * radius, v: 100})
-    this.setState({currentColor})
-    this.props.onColorChange({h: deg, s: 100 * radius, v: 100})
+    const hsv = {h: deg, s: 100 * radius, v: 100};
+    const currentColor = colorsys.hsv2Hex(hsv)
+    this.setState({hsv, currentColor})
+    this.props.onColorChange(hsv);
   }
 
   forceUpdate = color => {

--- a/README.md
+++ b/README.md
@@ -3,36 +3,42 @@
 
 :art: A react native reusable and color picker wheel
 
+## Usage
+
 ```javascript
 import React, { Component } from 'react';
-import {
-  Dimensions,
-  StyleSheet,
-  View
-} from 'react-native';
+import { Dimensions, StyleSheet, View } from 'react-native';
 import { ColorWheel } from 'react-native-color-wheel';
 
-export default class Example extends Component {
-  render() {
-    return (
-      <View style={{flex: 1}}>
-        <ColorWheel
-          initialColor="#ee0000"
-          onColorChange={color => console.log({color})}
-          style={{width: Dimensions.get('window').width}}
-          thumbStyle={{ height: 30, width: 30, borderRadius: 30}} />
-        <ColorWheel
-          initialColor="#00ee00"
-          style={{ marginLeft: 20, padding: 40, height: 200, width: 200 }} />
-      </View>
-    )
-  }
-}
+const Example = ({onChange}) => (
+  <View style={{flex: 1}}>
+    <ColorWheel
+      initialColor="#ee0000"
+      onColorChange={color => console.log({color})}
+      onColorChangeComplete={color => onChange(color)}
+      style={{width: Dimensions.get('window').width}}
+      thumbStyle={{ height: 30, width: 30, borderRadius: 30}}
+    />
+    <ColorWheel
+      initialColor="#00ee00"
+      style={{ marginLeft: 20, padding: 40, height: 200, width: 200 }}
+    />
+  </View>
+);
 ```
+
+## Props
+
+| Name                    | Description                                    | Type   |
+|-------------------------|------------------------------------------------|--------|
+| `initialColor`          | Initial value in hex format                    | String |
+| `onColorChange`         | Callback when the value is changed or moved    | func   |
+| `onColorChangeComplete` | Callback on mouseup or drag event has finished | func   |
+| `thumbSize`             | Width of draggable thumb                       | Number |
+| `thumbStyle`            | CSS for the draggable thumb                    | Object |
 
 <img alt="demo screenshot" src="screenshot.png" width="350" />
 
-More documentation is incoming, in the meanwhile please read the source code. It is a single file!
 PRs and issues are more than welcome.
 
 <a href="https://getyeti.co" target="_blank">


### PR DESCRIPTION
See #25.

For my use case, having an event listener for when the user finishes their drag movement is going to be more performant than debouncing my callback function.

To meet that requirement, this PR adds an `onColorChangeComplete` prop that gets called when the `PanResponder` is released in `onPanResponderRelease`.

In my tests, the complete function gets called for a normal press/release on the color wheel and finishing a drag movement.

Also added a table of props to README and removed unused `precision` prop.