### PR TITLE
Fix issue - Draggable thumb goes off the view

### DIFF
--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -227,8 +227,8 @@ export class ColorWheel extends Component {
         <Image
           style={[styles.img,
                   {
-                    height: radius * 2 - this.props.thumbSize,
-                    width: radius * 2 - this.props.thumbSize,
+                    height: radius * 2,
+                    width: radius * 2,
                     borderRadius: radius - this.props.thumbSize,
                   }]}
           source={require('./color-wheel.png')}

--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -202,16 +202,17 @@ export class ColorWheel extends Component {
         ref={node => {
           this.self = node
         }}
-        {...panHandlers}
         onLayout={nativeEvent => this.onLayout(nativeEvent)}
         style={[styles.coverResponder, this.props.style]}>
         <Image
-          style={[styles.img, 
+          style={[styles.img,
                   {
                     height: radius * 2 - this.props.thumbSize,
-                    width: radius * 2 - this.props.thumbSize
+                    width: radius * 2 - this.props.thumbSize,
+                    borderRadius: radius - this.props.thumbSize,
                   }]}
           source={require('./color-wheel.png')}
+          {...panHandlers}
         />
         <Animated.View style={[this.state.pan.getLayout(), thumbStyle]} />
       </View>

--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -18,12 +18,29 @@ export class ColorWheel extends Component {
     onColorChange: () => {},
   }
 
+  static getDerivedStateFromProps(props: Object, state: Object): null | Object {
+		const {
+      toggleMeToforceUpdateInitialColor,
+    } = props;
+		if (toggleMeToforceUpdateInitialColor !== state.toggleMeToforceUpdateInitialColor) {
+			return {
+        toggleMeToforceUpdateInitialColor,
+			};
+		}
+		return null;
+	}
+
   constructor (props) {
     super(props)
+    const {
+      initialColor,
+      toggleMeToforceUpdateInitialColor = 0,
+    } = props;
     this.state = {
       offset: {x: 0, y: 0},
-      currentColor: props.initialColor,
+      currentColor: initialColor,
       pan: new Animated.ValueXY(),
+      toggleMeToforceUpdateInitialColor,
       radius: 0,
       panHandlerReady: true,
       didUpdateThumb: false,
@@ -80,6 +97,16 @@ export class ColorWheel extends Component {
         }
       },
     })
+  }
+
+  componentDidUpdate(prevProps: Object, prevState: Object) {
+    const {
+      initialColor,
+    } = this.props;
+
+    if (initialColor && this.state.toggleMeToforceUpdateInitialColor !== prevState.toggleMeToforceUpdateInitialColor) {
+      this.forceUpdate(initialColor);
+    }
   }
 
   updateColorAndThumbPosition (nativeEvent) {

--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -26,6 +26,7 @@ export class ColorWheel extends Component {
       pan: new Animated.ValueXY(),
       radius: 0,
       panHandlerReady: true,
+      didUpdateThumb: false,
     }
   }
 
@@ -38,14 +39,14 @@ export class ColorWheel extends Component {
       onMoveShouldSetPanResponderCapture: () => true,
       onPanResponderGrant: ({nativeEvent}) => {
         if (this.outBounds(nativeEvent)) return
-        if (this.state.panHandlerReady) {
+        if (!this.state.didUpdateThumb) {
           this.updateColorAndThumbPosition(nativeEvent);
         }
       },
       onPanResponderMove: (event, gestureState) => {
         if (this.outBounds(gestureState)) return
 
-        if (this.state.panHandlerReady) {
+        if (!this.state.didUpdateThumb) {
           const {nativeEvent} = event;
           this.updateColorAndThumbPosition(nativeEvent);
         }
@@ -64,7 +65,10 @@ export class ColorWheel extends Component {
       },
       onMoveShouldSetPanResponder: () => true,
       onPanResponderRelease: ({nativeEvent}) => {
-        this.setState({panHandlerReady: true})
+        this.setState({
+          panHandlerReady: true,
+          didUpdateThumb: false,
+        })
         this.state.pan.flattenOffset()
         const {radius} = this.calcPolar(nativeEvent)
         if (radius < 0.1) {
@@ -84,6 +88,9 @@ export class ColorWheel extends Component {
     this.state.pan.setValue({
       x: -this.state.left + nativeEvent.pageX - this.props.thumbSize / 2,
       y: -this.state.top + nativeEvent.pageY - this.props.thumbSize / 2,
+    })
+    this.setState({
+      didUpdateThumb: true,
     })
   }
 

--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -25,27 +25,30 @@ export class ColorWheel extends Component {
       currentColor: props.initialColor,
       pan: new Animated.ValueXY(),
       radius: 0,
+      panHandlerReady: true,
     }
   }
 
   componentDidMount = () => {
     this._panResponder = PanResponder.create({
-      onStartShouldSetPanResponderCapture: ({nativeEvent}) => {
-        if (this.outBounds(nativeEvent)) return
-        this.updateColor({nativeEvent})
-        this.setState({panHandlerReady: true})
-
-        this.state.pan.setValue({
-          x: -this.state.left + nativeEvent.pageX - this.props.thumbSize / 2,
-          y: -this.state.top + nativeEvent.pageY - this.props.thumbSize / 2,
-        })
+      onStartShouldSetPanResponderCapture: () => {
         return true
       },
       onStartShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponderCapture: () => true,
-      onPanResponderGrant: () => true,
+      onPanResponderGrant: ({nativeEvent}) => {
+        if (this.outBounds(nativeEvent)) return
+        if (this.state.panHandlerReady) {
+          this.updateColorAndThumbPosition(nativeEvent);
+        }
+      },
       onPanResponderMove: (event, gestureState) => {
         if (this.outBounds(gestureState)) return
+
+        if (this.state.panHandlerReady) {
+          const {nativeEvent} = event;
+          this.updateColorAndThumbPosition(nativeEvent);
+        }
 
         this.resetPanHandler()
         return Animated.event(
@@ -72,6 +75,15 @@ export class ColorWheel extends Component {
           this.props.onColorChangeComplete(this.state.hsv);
         }
       },
+    })
+  }
+
+  updateColorAndThumbPosition (nativeEvent) {
+    this.updateColor({nativeEvent})
+
+    this.state.pan.setValue({
+      x: -this.state.left + nativeEvent.pageX - this.props.thumbSize / 2,
+      y: -this.state.top + nativeEvent.pageY - this.props.thumbSize / 2,
     })
   }
 

--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -203,7 +203,8 @@ export class ColorWheel extends Component {
           this.self = node
         }}
         onLayout={nativeEvent => this.onLayout(nativeEvent)}
-        style={[styles.coverResponder, this.props.style]}>
+        style={[styles.coverResponder, this.props.style]}
+        pointerEvents={'box-none'} >
         <Image
           style={[styles.img,
                   {
@@ -214,7 +215,7 @@ export class ColorWheel extends Component {
           source={require('./color-wheel.png')}
           {...panHandlers}
         />
-        <Animated.View style={[this.state.pan.getLayout(), thumbStyle]} />
+        <Animated.View style={[this.state.pan.getLayout(), thumbStyle]} pointerEvents={'box-none'} />
       </View>
     )
   }

--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -121,7 +121,7 @@ export class ColorWheel extends Component {
     })
   }
 
-  onLayout () {
+  onLayout = () => {
     this.measureOffset()
   }
 
@@ -227,6 +227,10 @@ export class ColorWheel extends Component {
     }).start()
   }
 
+  setRef = (ref) => {
+    this.self = ref;
+  }
+
   render () {
     const {radius} = this.state
     const thumbStyle = [
@@ -245,10 +249,8 @@ export class ColorWheel extends Component {
 
     return (
       <View
-        ref={node => {
-          this.self = node
-        }}
-        onLayout={nativeEvent => this.onLayout(nativeEvent)}
+        ref={this.setRef}
+        onLayout={this.onLayout}
         style={[styles.coverResponder, this.props.style]}
         pointerEvents={'box-none'} >
         <Image


### PR DESCRIPTION
Addressing the issue mentioned [here](https://github.com/netbeast/react-native-color-wheel/issues/40).

- Setting the pan handlers on the Image instead of the outer View.

- Also setting border radius on the Image.

- Some tweaks inside pan handler functions.
