### PR TITLE
Thumb pan responder should only onMoveShouldSetPanResponder

### DIFF
--- a/ColorWheel.js
+++ b/ColorWheel.js
@@ -41,8 +41,8 @@ export class ColorWheel extends Component {
         })
         return true
       },
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponderCapture: () => true,
+     
+      onMoveShouldSetPanResponder: () => true,
       onPanResponderGrant: () => true,
       onPanResponderMove: (event, gestureState) => {
         if (this.outBounds(gestureState)) return


### PR DESCRIPTION
Previously when tap on thumb its going off from the  touch because onStartShouldSetPanResponder is creating pan respondermove called on touched which causes issues in moving selector, i have removed onStartShouldSetPanResponder and replaced onMoveShouldSetPanResponderCapture to onMoveShouldSetPanResponder,
please look int the behaviour before and after